### PR TITLE
Fix redirecting to success when no user is found

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,10 @@ export class FormStrategy<User> extends Strategy<
       return await this.failure(message, request, sessionStorage, options);
     }
 
+    if (!user) {
+      return await this.failure("No user found", request, sessionStorage, options);
+    }
+
     return this.success(user, request, sessionStorage, options);
   }
 }


### PR DESCRIPTION
Currently, the user is redirected to `successRedirect`only when an error occurs. However, an error doesn't seem to occur if the user simply doesn't exist. This PR adjusts the check to ensure that the user is redirected to `failureRedirect` if there is no user but no error occurs