### PR TITLE
Require at least remix-auth 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "remix-auth": "^3.1.0"
+    "remix-auth": "^3.3.0"
   }
 }


### PR DESCRIPTION
I ran into an issue where passing formData via context (https://github.com/sergiodxa/remix-auth-form/commit/711b39e247831c1f94c5c0bdd19aa979b419c77e) doesn't work without https://github.com/sergiodxa/remix-auth/commit/50a58e0ec194dd854d900ae65c4b8d5fde47834e. This commit bumps the remix-auth dependency to the version that includes that commit.