### PR TITLE
Use `ActionArgs` instead of `ActionFunction`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ export async function action({ context, request }: ActionArgs) {
 Because you may want to do validations or read valeus from the FormData before calling `authenticate`, the FormStrategy allows you to pass a FormData object as part of the optional context.
 
 ```ts
-export async action function({ context, request }: ActionArgs) {
+export async function action({ context, request }: ActionArgs) {
   let formData = await request.formData();
   return await authenticator.authenticate("form", request, {
     // use formData here

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ authenticator.use(
 In order to authenticate a user, you can use the following inside of an ActionFunction:
 
 ```ts
-export const action: ActionFunction = async ({ request, context }) => {
+export const action = async ({ context, request }: ActionArgs) => {
   return await authenticator.authenticate("form", request, {
     successRedirect: "/",
     failureRedirect: "/login",
@@ -81,7 +81,7 @@ export const action: ActionFunction = async ({ request, context }) => {
 Because you may want to do validations or read valeus from the FormData before calling `authenticate`, the FormStrategy allows you to pass a FormData object as part of the optional context.
 
 ```ts
-export const action: ActionFunction = async ({ request, context }) => {
+export const action = async ({ context, request }: ActionArgs) => {
   let formData = await request.formData();
   return await authenticator.authenticate("form", request, {
     // use formData here

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ authenticator.use(
 );
 ```
 
-In order to authenticate a user, you can use the following inside of an ActionFunction:
+In order to authenticate a user, you can use the following inside of an `action` function:
 
 ```ts
 export const action = async ({ context, request }: ActionArgs) => {

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ authenticator.use(
 In order to authenticate a user, you can use the following inside of an `action` function:
 
 ```ts
-export const action = async ({ context, request }: ActionArgs) => {
+export async function action({ context, request }: ActionArgs) {
   return await authenticator.authenticate("form", request, {
     successRedirect: "/",
     failureRedirect: "/login",
@@ -81,7 +81,7 @@ export const action = async ({ context, request }: ActionArgs) => {
 Because you may want to do validations or read valeus from the FormData before calling `authenticate`, the FormStrategy allows you to pass a FormData object as part of the optional context.
 
 ```ts
-export const action = async ({ context, request }: ActionArgs) => {
+export async action function({ context, request }: ActionArgs) {
   let formData = await request.formData();
   return await authenticator.authenticate("form", request, {
     // use formData here


### PR DESCRIPTION
To comply with new usage of `useActionData`/`useLoaderData` hooks

---

Just like https://github.com/sergiodxa/remix-auth/pull/196