### PR TITLE
Move `this.readFormData` within the `try`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,9 +31,8 @@ export class FormStrategy<User> extends Strategy<
 		sessionStorage: SessionStorage,
 		options: AuthenticateOptions,
 	): Promise<User> {
-		let form = await this.readFormData(request, options);
-
 		try {
+			let form = await this.readFormData(request, options);
 			let user = await this.verify({ form, context: options.context, request });
 			return this.success(user, request, sessionStorage, options);
 		} catch (error) {


### PR DESCRIPTION
Currently, If the request is an invalid POST then this will fail with `Could not parse content as FormData`, resulting in an uncatchable 500 error returned to the client.
This change causes errors in the request parsing to instead route to the `this.failure` function.