### PR TITLE
docs(readme): fix example usage for action function

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,19 @@ In order to authenticate a user, you can use the following inside of an `action`
 
 ```ts
 export async function action({ context, request }: ActionArgs) {
-  return await authenticator.authenticate("form", request, {
-    successRedirect: "/",
-    failureRedirect: "/login",
-    context, // optional
-  });
+  try {
+    return await authenticator.authenticate("form", request, {
+      successRedirect: "/",
+      failureRedirect: "/login",
+      context, // optional
+    });
+  } catch (err) {
+    // You need this to trigger successRedirect
+    if (err instanceof Response) {
+      throw err;
+    }
+  
+    // return errors
+  }
 }
 ```


### PR DESCRIPTION
Fix #41 

successRedirect is not triggered in actions, turns out we need to throw the response.